### PR TITLE
build: make: use jemalloc by default and allow opt-in to scudo (1/3)

### DIFF
--- a/core/config_sanitizers.mk
+++ b/core/config_sanitizers.mk
@@ -299,7 +299,7 @@ ifneq ($(filter address thread hwaddress,$(my_sanitize)),)
 endif
 
 # Or if disabled globally.
-ifeq ($(PRODUCT_DISABLE_SCUDO),true)
+ifneq ($(PRODUCT_USE_SCUDO),true)
   my_sanitize := $(filter-out scudo,$(my_sanitize))
 endif
 

--- a/core/product.mk
+++ b/core/product.mk
@@ -260,8 +260,8 @@ _product_list_vars += PRODUCT_MEMTAG_HEAP_EXCLUDE_PATHS
 # Whether this product wants to start with an empty list of default memtag_heap include paths
 _product_single_value_vars += PRODUCT_MEMTAG_HEAP_SKIP_DEFAULT_PATHS
 
-# Whether the Scudo hardened allocator is disabled platform-wide
-_product_single_value_vars += PRODUCT_DISABLE_SCUDO
+# Whether the Scudo hardened allocator is enabled platform-wide
+_product_single_value_vars += PRODUCT_USE_SCUDO
 
 # List of extra VNDK versions to be included
 _product_list_vars += PRODUCT_EXTRA_VNDK_VERSIONS

--- a/core/soong_config.mk
+++ b/core/soong_config.mk
@@ -126,8 +126,6 @@ $(call add_json_list, MemtagHeapExcludePaths,            $(MEMTAG_HEAP_EXCLUDE_P
 $(call add_json_list, MemtagHeapAsyncIncludePaths,       $(MEMTAG_HEAP_ASYNC_INCLUDE_PATHS) $(PRODUCT_MEMTAG_HEAP_ASYNC_INCLUDE_PATHS) $(if $(filter true,$(PRODUCT_MEMTAG_HEAP_SKIP_DEFAULT_PATHS)),,$(PRODUCT_MEMTAG_HEAP_ASYNC_DEFAULT_INCLUDE_PATHS)))
 $(call add_json_list, MemtagHeapSyncIncludePaths,       $(MEMTAG_HEAP_SYNC_INCLUDE_PATHS) $(PRODUCT_MEMTAG_HEAP_SYNC_INCLUDE_PATHS) $(if $(filter true,$(PRODUCT_MEMTAG_HEAP_SKIP_DEFAULT_PATHS)),,$(PRODUCT_MEMTAG_HEAP_SYNC_DEFAULT_INCLUDE_PATHS)))
 
-$(call add_json_bool, DisableScudo,                      $(filter true,$(PRODUCT_DISABLE_SCUDO)))
-
 $(call add_json_bool, ClangTidy,                         $(filter 1 true,$(WITH_TIDY)))
 $(call add_json_str,  TidyChecks,                        $(WITH_TIDY_CHECKS))
 

--- a/target/product/go_defaults_common.mk
+++ b/target/product/go_defaults_common.mk
@@ -41,11 +41,6 @@ PRODUCT_ART_TARGET_INCLUDE_DEBUG_BUILD := false
 # leave less information available via JDWP.
 PRODUCT_MINIMIZE_JAVA_DEBUG_INFO := true
 
-# Disable Scudo outside of eng builds to save RAM.
-ifneq (,$(filter eng, $(TARGET_BUILD_VARIANT)))
-  PRODUCT_DISABLE_SCUDO := true
-endif
-
 # Add the system properties.
 TARGET_SYSTEM_PROP += \
     build/make/target/board/go_defaults_common.prop


### PR DESCRIPTION
Set "PRODUCT_USE_SCUDO := true" to device.mk to use scudo in case of a jemalloc compatibility issue.

Also, clean up broken DisableScudo/PRODUCT_DISABLE_SCUDO.

Detailed reason for switching to jemalloc by default is written in the bionic commit.

Change-Id: I0983c48c1d11afb7820aad66c2838e5e3e13e6e8