### PR TITLE
build: Squash of allowing a device to generically define its own headers

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -1355,6 +1355,11 @@ my_tracked_gen_files :=
 $(foreach f,$(my_tracked_src_files),$(eval my_src_file_obj_$(s):=))
 my_tracked_src_files :=
 
+## Allow a device's own headers to take precedence over global ones
+ifneq ($(TARGET_SPECIFIC_HEADER_PATH),)
+my_c_includes := $(TOPDIR)$(TARGET_SPECIFIC_HEADER_PATH) $(my_c_includes)
+endif
+
 my_c_includes += $(TOPDIR)$(LOCAL_PATH) $(intermediates) $(generated_sources_dir)
 
 my_c_includes := $(foreach inc,$(my_c_includes),$(call clean-path,$(inc)))

--- a/core/soong_config.mk
+++ b/core/soong_config.mk
@@ -144,6 +144,7 @@ $(call add_json_bool, ArtUseReadBarrier,                 $(call invert_bool,$(fi
 $(call add_json_bool, Binder32bit,                       $(BINDER32BIT))
 $(call add_json_str,  BtConfigIncludeDir,                $(BOARD_BLUETOOTH_BDROID_BUILDCFG_INCLUDE_DIR))
 $(call add_json_list, DeviceKernelHeaders,               $(TARGET_DEVICE_KERNEL_HEADERS) $(TARGET_BOARD_KERNEL_HEADERS) $(TARGET_PRODUCT_KERNEL_HEADERS))
+$(call add_json_str,  TargetSpecificHeaderPath,          $(TARGET_SPECIFIC_HEADER_PATH))
 $(call add_json_str,  DeviceVndkVersion,                 $(BOARD_VNDK_VERSION))
 $(call add_json_str,  Platform_vndk_version,             $(PLATFORM_VNDK_VERSION))
 $(call add_json_str,  ProductVndkVersion,                $(PRODUCT_PRODUCT_VNDK_VERSION))


### PR DESCRIPTION
Author: Ricardo Cerqueira <cyanogenmod@cerqueira.org>
Date:   2011-04-12 10:57:22 +0100
    Allow a device to generically define its own headers

    We have a few cases of devices including specific versions of projects
    just because of modified headers (msm_mdp.h comes to mind), and I just
    had enough of ifdeffing header files for specific cases (the P990 needs
    a lot of these).
    Now... if a target defines a TARGET_SPECIFIC_HEADER_PATH, any headers in
    there will take precedence over the standard ones; for example, on the
    p990, I have

    TARGET_SPECIFIC_HEADER_PATH := device/lge/p990/include

    which makes, for example, the
    device/lge/p990/include/hardware_legacy/AudioHardwareInterface.h be
    used instead of
    hardware/libhardware_legacy/include/hardware_legacy/AudioHardwareInterface.h
    whenever a source file uses <hardware_legacy/AudioHardwareInterface.h>

    Change-Id: I41b62668b60e3f62a6ebd3738d8d2675103a81e6a

    build: fix target header overlay

    LOCAL_C_INCLUDES as defined by the makefile should be put AFTER
    the overlay includes so the overlay always takes precedence.

    Change-Id: I489b2aab6dbacd9122d834f85e07b63ed1271f07

Author: Jan Altensen <info@stricted.net>
Date:   2020-09-10 15:18:49 +0200
    soong: add TARGET_SPECIFIC_HEADER_PATH

    Change-Id: I582ae8e6e010016b33fd9b020b723e5fc2dc442b

Change-Id: I3c885fe504ce4f646001697119cffd674db9ec49